### PR TITLE
Fix left/right typo describing luminance_vs_color image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Our eyes are [more sensible to brightness than colors](http://vanseodesign.com/w
 
 ![luminance vs color](/i/luminance_vs_color.png "luminance vs color")
 
-If you are unable to see that the colors of the **squares A and B are identical** in the right side, that's fine, it's our brain playing tricks on us to **pay more attention to light and dark than color**. There is a connector, with the same color, on the left side so we (our brain) can easily spot that in fact, they're the same color.
+If you are unable to see that the colors of the **squares A and B are identical** on the left side, that's fine, it's our brain playing tricks on us to **pay more attention to light and dark than color**. There is a connector, with the same color, on the right side so we (our brain) can easily spot that in fact, they're the same color.
 
 > **Simplistic explanation about our eyes**
 >


### PR DESCRIPTION
For the [luminance_vs_color image](https://github.com/leandromoreira/digital_video_introduction/blob/master/i/luminance_vs_color.png) the connector is described as being on the left side when it's actually on the right.