### PR TITLE
Call `pwd` command in mediainfo script.

### DIFF
--- a/s/mediainfo
+++ b/s/mediainfo
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run --rm -v $(PWD):/files leandromoreira/mediainfo $@
+docker run --rm -v $(pwd):/files leandromoreira/mediainfo $@


### PR DESCRIPTION
I was seeing the following error when I ran the [Inspect Stream](https://github.com/leandromoreira/digital_video_introduction/blob/master/enconding_pratical_examples.md#inspect-stream)" examples:

```bash
$ ./s/mediainfo /files/v/small_bunny_1080p_30fps.mp4
./s/mediainfo: line 2: PWD: command not found
docker: Error response from daemon: invalid volume spec ":/files": invalid volume specification: ':/files'.
See 'docker run --help'.
```

This PR calls "`pwd`" instead of "`PWD`".