### PR TITLE
s/download_video: add -c option to wget when download the video

### DIFF
--- a/s/download_video.sh
+++ b/s/download_video.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-wget -O v/bunny_1080p_60fps.mp4 http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_60fps_normal.mp4
-wget -O v/bunny_1080p_30fps.mp4 http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4
+wget -c -O v/bunny_1080p_60fps.mp4 http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_60fps_normal.mp4
+wget -c -O v/bunny_1080p_30fps.mp4 http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4


### PR DESCRIPTION
It's useful if the connection drops during a download of the video
file and instead of staring the download from scratch it can
continue the previous one.

Signed-off-by: Jun Zhao <barryjzhao@tencent.com>