### PR TITLE
version/tag added to ffmpeg docker image

### DIFF
--- a/encoding_pratical_examples.md
+++ b/encoding_pratical_examples.md
@@ -202,7 +202,7 @@ It generates a video with motion vector over the video.
 Get `images` from `1s video`:
 
 ```
-./s/ffmpeg -y -i /files/v/bunny_1080p_30fps.mp4 -ss 00:01:24 -t 00:00:01  /files/v/smallest_bunny_1080p_30fps_%3d.jpg
+./s/ffmpeg -y -i /files/v/small_bunny_1080p_30fps.mp4 -ss 00:01:24 -t 00:00:01  /files/v/smallest_bunny_1080p_30fps_%3d.jpg
 ```
 
 ## Generate video from images

--- a/s/ffmpeg
+++ b/s/ffmpeg
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run --rm -v $(pwd):/files jrottenberg/ffmpeg $@
+docker run --rm -v $(pwd):/files jrottenberg/ffmpeg:3.3 $@


### PR DESCRIPTION
`3.3` version tag added to `jrottenberg/ffmpeg` docker image in order to support the `vis_mb_type` option  used in [debug video example](https://github.com/leandromoreira/digital_video_introduction/blob/master/encoding_pratical_examples.md#generate-debug-video).