### PR TITLE
Specify tag to `jupyter/scipy-notebook` image

### DIFF
--- a/s/start_jupyter.sh
+++ b/s/start_jupyter.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-docker run --rm -p 8888:8888 -v $(pwd):/home/jovyan/work jupyter/scipy-notebook
+# Run Jupyter Notebook (Python 3.5.2, scipy 0.17.1)
+docker run --rm -p 8888:8888 -v $(pwd):/home/jovyan/work  jupyter/scipy-notebook:387f29b6ca83


### PR DESCRIPTION
close #115 

`scipy.misc.bytescale` method does not exists in  `jupyter/scipy-notebook:latest` docker image, because latest image contains `scipy 1.6.3`. `scipy.misc.bytescale` module was deprecated when `v1.0.0` was released.

I specified tag to `jupyter/scipy-notebook` image. 
https://hub.docker.com/layers/jupyter/scipy-notebook/387f29b6ca83/images/sha256-d4953b52e6a53736aab92b5f82a764f71f8592851a54dff513e0c82ba1cc6c02?context=explore



```
import sys
sys.version
# '3.5.2 |Continuum Analytics, Inc.| (default, Jul  2 2016, 17:53:06) \n[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]'

import scipy
scipy.__version__
# '0.17.1'

```
