### PR TITLE
fix usage of decrypted bytescale

### DIFF
--- a/dct_better_explained.ipynb
+++ b/dct_better_explained.ipynb
@@ -25,7 +25,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy import fftpack\n",
-    "from scipy.misc import bytescale\n",
+    "from skimage.util import img_as_ubyte\n",
     "import matplotlib.image as mpimg"
    ]
   },
@@ -59,7 +59,7 @@
    ],
    "source": [
     "# loading a simple Z character image (8x8)\n",
-    "img = bytescale(mpimg.imread('i/z_char_8x8.png'))\n",
+    "img = img_as_ubyte(mpimg.imread('i/z_char_8x8.png'))\n",
     "img_h = 8\n",
     "gray_img = img[:,:,0]\n",
     "\n",
@@ -179,7 +179,7 @@
     }
    ],
    "source": [
-    "dct_basis = bytescale(mpimg.imread('i/dct_basis.png'))\n",
+    "dct_basis = img_as_ubyte(mpimg.imread('i/dct_basis.png'))\n",
     "plt.imshow(dct_basis, cmap='gray', interpolation='nearest')"
    ]
   },

--- a/dct_experiences.ipynb
+++ b/dct_experiences.ipynb
@@ -25,7 +25,6 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy import fftpack\n",
-    "from scipy.misc import bytescale\n",
     "import matplotlib.image as mpimg"
    ]
   },

--- a/uniform_quantization_experience.ipynb
+++ b/uniform_quantization_experience.ipynb
@@ -25,7 +25,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy import fftpack\n",
-    "from scipy.misc import bytescale\n",
+    "from skimage.util import img_as_ubyte\n",
     "import matplotlib.image as mpimg"
    ]
   },
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "# loading image\n",
-    "img = bytescale(mpimg.imread('i/super_mario_head.png'))\n",
+    "img = img_as_ubyte(mpimg.imread('i/super_mario_head.png'))\n",
     "choosen_y_x = 90\n",
     "resolution = 128\n",
     "\n",


### PR DESCRIPTION
The func scipy.misc.bytescale become decrypted as can see [here](https://docs.scipy.org/doc/scipy/release.1.3.0.html?highlight=bytescale#backwards-incompatible-changes).  
The PR follow [this suggestion](https://github.com/scipy/scipy/issues/10346) and use skimage.util.img_as_ubyte with same functionality in some notebooks.