### PR TITLE
add path escaping to `start_jupyter.sh`

### DIFF
--- a/s/start_jupyter.sh
+++ b/s/start_jupyter.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Run Jupyter Notebook (Python 3.5.2, scipy 0.17.1)
-docker run --rm -p 8888:8888 -v $(pwd):/home/jovyan/work  jupyter/scipy-notebook:387f29b6ca83
+docker run --rm -p 8888:8888 -v "$(pwd)":/home/jovyan/work  jupyter/scipy-notebook:387f29b6ca83


### PR DESCRIPTION
with this proposed change, `$(pwd)` is escaped and users won't receive errors if the working directory path includes space for example.